### PR TITLE
Add NeoPixelBus as an alternative to FastLED

### DIFF
--- a/ConfigStatic.h.example
+++ b/ConfigStatic.h.example
@@ -12,19 +12,36 @@
 //#define LOGLEVEL LOG_LEVEL_VERBOSE
 
 /*------------------------------------------------*/
+/*Hardware library support*/
+#define HW_FASTLED 1
+//#define HW_NEOPIXEL 1
+
+/*------------------------------------------------*/
 /*Main configuration*/
 
 #define CONFIG_WIFI_SSID "ssid"
 #define CONFIG_WIFI_PASSWORD "password"
 #define CONFIG_WIFI_HOSTNAME "ESP8266"
 
-#define CONFIG_LED_SPI_CHIPSET WS2801 //Comment out for clockless
-//#define CONFIG_LED_CLOCKLESS_CHIPSET WS2812B
-#define CONFIG_LED_DATAPIN D1
-#define CONFIG_LED_CLOCKPIN D2 //Comment out for clockless
+#ifdef HW_FASTLED
+  #define CONFIG_LED_CLOCKLESS_CHIPSET WS2812B
+//  #define CONFIG_LED_SPI_CHIPSET WS2801 //Comment out for clockless
+//  #define CONFIG_LED_CLOCKPIN D2 //Comment out for clockless
+  #define CONFIG_LED_COLOR_ORDER GRB
+  #define FASTLED_ESP8266_RAW_PIN_ORDER 1
+#elif HW_NEOPIXEL
+  #define CONFIG_NEO_METHOD   NeoEsp8266Uart800KbpsMethod   //one in NeoEsp8266DMA800KbpsMethod, NeoEsp8266Uart800KbpsMethod, NeoEsp8266BitBang800KbpsMethod
+  #define CONFIG_NEO_FEATURE  NeoGrbFeature					//one in NeoGrbFeature, NeoGrbwFeature, NeoRgbFeature, NeoRgbwFeature, NeoBrgFeature, NeoRbgFeature
+#endif
 
-#define CONFIG_LED_COLOR_ORDER RGB
+#define CONFIG_LED_DATAPIN 2  // ignored for NeoEsp8266Uart800KbpsMethod (Auto-Pin 2) and NeoEsp8266DMA800KbpsMethod (Auto-Pin 3)
 #define CONFIG_LED_COUNT 50
+
+#ifdef HW_FASTLED
+  #define CONFIG_MAX_COLOR 255
+#elif HW_NEOPIXEL
+  #define CONFIG_MAX_COLOR 127
+#endif
 
 #define CONFIG_PORT_UDP_LED 19446
 #define CONFIG_PORT_JSON_SERVER 19444

--- a/HyperionRGB.ino
+++ b/HyperionRGB.ino
@@ -17,7 +17,7 @@
   #include "WrapperWebconfig.h"
 #endif
 
-#define LED D0 // LED in NodeMCU at pin GPIO16 (D0).
+#define LED 0 // LED in NodeMCU at pin GPIO16 (D0).
 int ledState = LOW;
 
 LoggerInit loggerInit;
@@ -88,7 +88,11 @@ void loop(void) {
 
 void updateLed(int id, byte r, byte g, byte b) {
   Log.verbose("LED %i, r=%i, g=%i, b=%i", id + 1, r, g, b);
-  ledStrip.leds[id].setRGB(r, g, b);
+  #ifdef HW_FASTLED
+    ledStrip.leds[id].setRGB(r, g, b);
+  #elif HW_NEOPIXEL
+    ledStrip.setPixel( id, r, g, b );
+  #endif
 }
 void refreshLeds(void) {
   Log.debug("refresh LEDs");

--- a/WrapperFastLed.h
+++ b/WrapperFastLed.h
@@ -2,7 +2,14 @@
 #define WrapperFastLed_h
 
 #include "BaseHeader.h"
-#include <FastLED.h>
+#ifdef HW_FASTLED
+  #include <FastLED.h>
+#elif HW_NEOPIXEL
+  #include <NeoPixelBus.h>
+#endif
+
+#define colorSaturation CONFIG_MAX_COLOR
+#define colorFactor 255 / CONFIG_MAX_COLOR
 
 class WrapperFastLed {
   public:
@@ -14,19 +21,32 @@ class WrapperFastLed {
       #endif
       show(void),
       clear(void),
-      fillSolid(CRGB color),
+      #ifdef HW_FASTLED
+        fillSolid(CRGB color),
+      #elif HW_NEOPIXEL
+        setPixel(byte i, byte r, byte g, byte b),
+        fillSolid(RgbColor color),
+      #endif
       fillSolid(byte r, byte g, byte b),
       rainbowStep(void);
 
-    CRGB* leds;
+    #ifdef HW_FASTLED
+      CRGB* leds;
+    #elif HW_NEOPIXEL
+      typedef NeoPixelBus<CONFIG_NEO_FEATURE, CONFIG_NEO_METHOD> MyPixelBus;
+      MyPixelBus * strip;
+    #endif
       
   private: 
-   #ifdef CONFIG_TYPE_WEBCONFIG
-    void 
-        addLeds(uint8_t chipset, uint8_t dataPin, uint8_t clockPin, uint8_t colorOrder, uint16_t ledCount);
-   #endif
-      
-    CRGB wheel(byte wheelPos);
+    #ifdef HW_FASTLED
+      #ifdef CONFIG_TYPE_WEBCONFIG
+       void 
+         addLeds(uint8_t chipset, uint8_t dataPin, uint8_t clockPin, uint8_t colorOrder, uint16_t ledCount);
+      #endif
+      CRGB wheel(byte wheelPos);
+    #elif HW_NEOPIXEL
+      RgbColor wheel(byte wheelPos);
+    #endif
     byte _rainbowStepState;
     int _ledCount;
 };


### PR DESCRIPTION
Added config option HW_FASTLED / HW_NEOPIXEL in order to replace FastLED hardware library with NeoPixelBus (https://github.com/Makuna/NeoPixelBus) for clockless strips (like WS2812B).
FastLED currently only supports bit banging while NeoPixelBus allows for DMA or UART interface which in turn should lead to a more stable network connection.
